### PR TITLE
fix: resolved two bugs

### DIFF
--- a/bioguider/agents/evaluation_installation_task.py
+++ b/bioguider/agents/evaluation_installation_task.py
@@ -211,6 +211,8 @@ class EvaluationInstallationTask(EvaluationTask):
             instruction_prompt=EVALUATION_INSTRUCTION,
             schema=StructuredEvaluationInstallationResult,
         )
+        res: StructuredEvaluationInstallationResult = res
+        res.dependency_number = 0 if res.dependency_number is None else res.dependency_number
         self.print_step(step_output=reasoning_process)
         self.print_step(token_usage=token_usage)
 

--- a/bioguider/database/summarized_file_db.py
+++ b/bioguider/database/summarized_file_db.py
@@ -114,7 +114,7 @@ class SummarizedFilesDb:
         file_path: str,
         instruction: str,
         summarize_level: int,
-        summarize_prompt: str,
+        summarize_prompt: str = "N/A",
     ) -> str | None:
         self._connect_to_db()
         self._ensure_tables()

--- a/tests/test_summarized_file_db.py
+++ b/tests/test_summarized_file_db.py
@@ -15,7 +15,8 @@ class SummarizedFilesDbTestCase(unittest.TestCase):
             "111/222/333",
             "",
             3,
-            "balahbalah balahbalah balahbalah"
+            "balahbalah balahbalah balahbalah",
+            "N/A",
         )
     def tearDown(self):
         if self.db is None:
@@ -28,7 +29,8 @@ class SummarizedFilesDbTestCase(unittest.TestCase):
             "aaa/bbb/ccc",
             "",
             3,
-            "balahbalah balahbalah balahbalah"
+            "balahbalah balahbalah balahbalah",
+            "N/A",
         )
         self.assertTrue(res)
 
@@ -51,6 +53,7 @@ class SummarizedFilesDbTestCase(unittest.TestCase):
             "",
             3,
             "balahbalah",
+            "N/A",
             token_usage,
         )
         self.assertTrue(res)


### PR DESCRIPTION
### Abstract
This submission fixed two bugs:
1. In function select_summarized_text, provide default value for  args `summarize_prompt`
2. Add protective code for dependency_number in installation evaluation result.