### PR TITLE
chore: remove broken RepoAgent submodule and correct docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ Three orchestrator classes in `bioguider/managers/` drive everything; each compo
 - `system_tests/` are real integration tests — they will clone repos and spend LLM tokens. Flag before running them in bulk.
 - The `refactor/document-generation` branch has been progressively breaking the generation pipeline into the small modules listed above (Phase 1 through 2.5 per the commit log). When touching generation, prefer the `bioguider/generation/*` components over anything that looks monolithic — the monolithic version may still be referenced in older tests.
 - `DeepSeekConversation.chat` swallows exceptions and returns them stringified (see `bioguider/conversation.py`). Don't assume a successful return type.
-- The `RepoAgent/` subdirectory is a vendored third-party library (OpenBMB/RepoAgent), not part of the bioguider package. Don't edit it.
+- `RepoAgent` (OpenBMB/RepoAgent) is an external repository used as a sample target by the `*_RepoAgent` evaluation system tests — not part of the bioguider package and not a dependency. Those tests clone it to the sibling path defined by `system_tests/conftest.py`'s `root_path` fixture (e.g. `../RepoAgent`); it is no longer a submodule of this repo.
 
 ## Security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Three orchestrator classes in `bioguider/managers/` drive everything; each compo
 - `system_tests/` are real integration tests — they will clone repos and spend LLM tokens. Flag before running them in bulk.
 - The `refactor/document-generation` branch has been progressively breaking the generation pipeline into the small modules listed above (Phase 1 through 2.5 per the commit log). When touching generation, prefer the `bioguider/generation/*` components over anything that looks monolithic — the monolithic version may still be referenced in older tests.
 - `DeepSeekConversation.chat` swallows exceptions and returns them stringified (see `bioguider/conversation.py`). Don't assume a successful return type.
-- The `RepoAgent/` subdirectory is a vendored third-party library (OpenBMB/RepoAgent), not part of the bioguider package. Don't edit it.
+- `RepoAgent` (OpenBMB/RepoAgent) is an external repository used as a sample target by the `*_RepoAgent` evaluation system tests — not part of the bioguider package and not a dependency. Those tests clone it to the sibling path defined by `system_tests/conftest.py`'s `root_path` fixture (e.g. `../RepoAgent`); it is no longer a submodule of this repo.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,9 @@ hard-coded to a specific server path and will only run on that host.
 
 - Follow the existing module conventions — especially the PEO quadruple for new agent
   capabilities and the small `bioguider/generation/*` components for pipeline work.
-- `RepoAgent/` is a vendored third party (OpenBMB/RepoAgent) — **do not edit it**.
+- `RepoAgent` (OpenBMB/RepoAgent) is an external repository used as a sample target for the
+  evaluation system tests, not a dependency of the package. The `*_RepoAgent` system tests expect a
+  clone at the sibling path in `system_tests/conftest.py`'s `root_path` fixture (e.g. `../RepoAgent`).
 - Cut releases with `bump2version patch|minor|major` (config in `.bumpversion.cfg`).
 
 ## License

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -151,7 +151,7 @@ All of these directories are **gitignored and regeneratable**:
 - **`system_tests/`** make real LLM calls, clone real repos, and cost money — run them
   deliberately, one file at a time.
 - **`DeepSeekConversation.chat`** swallows exceptions and returns them stringified.
-- **`RepoAgent/`** is vendored third-party (OpenBMB/RepoAgent) — do not edit it.
+- **`RepoAgent`** (OpenBMB/RepoAgent) is an external repository used as a sample target by the `*_RepoAgent` evaluation system tests — not a dependency of the package. It is expected as a sibling clone (see `root_path` in `system_tests/conftest.py`), not a submodule of this repo.
 - The generation pipeline has been progressively broken into the small
   `bioguider/generation/*` components; prefer those over any monolithic version still
   referenced by older tests.


### PR DESCRIPTION
RepoAgent was registered as a git submodule (gitlink, mode 160000) but had no .gitmodules entry, so the reference was orphaned: the directory was empty and could not be populated. The bioguider package never references RepoAgent; it is only used by the *_RepoAgent evaluation system tests, which expect an external clone at the sibling path defined by conftest.py's root_path fixture.

- Remove the orphaned gitlink and empty directory.
- Fix README.md, CLAUDE.md, AGENTS.md, and docs/ARCHITECTURE.md, which incorrectly described RepoAgent as a vendored third-party dependency; it is an external test-target repository, not part of the package.